### PR TITLE
gemspec: Allow Bundler 2, too

### DIFF
--- a/jwt_authentication.gemspec
+++ b/jwt_authentication.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rack-test"


### PR DESCRIPTION
This PR loosens the gemspec requirement of Bundler ~> 1 to **allow Bundler 2** to be used.