### PR TITLE
spec: Fix expectation

### DIFF
--- a/spec/request/jwt_authentication_spec.rb
+++ b/spec/request/jwt_authentication_spec.rb
@@ -206,7 +206,7 @@ describe JwtAuthentication do
       data, session = TestCustomSessionPersisterApp::CustomSsoSessionPersister.data
       expect(data.keys.sort).to eq(["exp", "user"])
       expect(data["user"]).to eq({ "email" => "foo@example.com", "name" => "Foo" })
-      expect(session.class).to eq(Rack::Session::Abstract::SessionHash)
+      expect(session).to be_kind_of(Rack::Session::Abstract::SessionHash)
     end
   end
 


### PR DESCRIPTION
This PR makes the tests go green 🟢 

 - the class now has a deeper structure, but the same parent class